### PR TITLE
update peerDependency for react v15.0 and react-dom v15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     "webpack-dev-server": "^1.14.1"
   },
   "peerDependencies": {
-    "react": "^0.14 || ^0.15",
-    "react-dom": "^0.14 || ^0.15"
+    "react": "^0.14 || ^15.0",
+    "react-dom": "^0.14 || ^15.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",


### PR DESCRIPTION
0.15 isn't a react (or react-dom) version, should this be 15.0?

https://github.com/facebook/react/releases