### PR TITLE
#68: datepicker layout may break with different fonts (closes #68)

### DIFF
--- a/examples/webpack.base.babel.js
+++ b/examples/webpack.base.babel.js
@@ -7,13 +7,18 @@ export const paths = {
   SRC: path.resolve(__dirname, '../src'),
   ENTRY: path.resolve(__dirname, 'examples.js'),
   BUILD: path.resolve(__dirname, 'build'),
-  EXAMPLES: path.resolve(__dirname)
+  EXAMPLES: path.resolve(__dirname),
+  NODE_MODULES: path.resolve(__dirname, 'node_modules')
 };
 
 export default {
   output: {
     path: paths.BUILD,
     filename: 'bundle.js'
+  },
+
+  resolve: {
+    root: [paths.NODE_MODULES]
   },
 
   module: {

--- a/examples/webpack.config.babel.js
+++ b/examples/webpack.config.babel.js
@@ -22,7 +22,7 @@ export default {
     ...webpackBase.module,
     loaders: webpackBase.module.loaders.concat([{
       test: /\.scss$/,
-      loader: ExtractTextPlugin.extract('style', 'css?sourceMap!sass?sourceMap')
+      loader: ExtractTextPlugin.extract('style', 'css!resolve-url!sass?sourceMap')
     }])
   },
 

--- a/examples/webpack.config.build.babel.js
+++ b/examples/webpack.config.build.babel.js
@@ -13,7 +13,7 @@ export default {
     ...webpackBase.module,
     loaders: webpackBase.module.loaders.concat([{
       test: /\.scss$/,
-      loader: ExtractTextPlugin.extract('style', 'css?sourceMap!sass?sourceMap')
+      loader: ExtractTextPlugin.extract('style', 'css!resolve-url!sass?sourceMap')
     }])
   },
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-addons-test-utils": "^0.14.8",
     "react-dom": "^0.14",
     "require-dir": "^0.3.0",
+    "resolve-url-loader": "^1.6.0",
     "sass-loader": "^3.2.0",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.1",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "classnames": "^2.2.5",
     "lodash": "^4.13.1",
     "moment": "^2.13.0",
+    "react-flexview": "0.0.1",
     "revenge": "^0.4.4",
     "tcomb": "^3.2.1",
     "tcomb-react": "^0.9.0"

--- a/src/Input.js
+++ b/src/Input.js
@@ -2,6 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import { props } from 'tcomb-react';
 import t from 'tcomb';
+import View from 'react-flexview';
 import skinnable from './utils/skinnable';
 import pure from './utils/pure';
 
@@ -63,17 +64,17 @@ export default class Input extends React.Component {
 
   templateInputButton({ className, onButtonClick, iconClassName }) {
     return (
-      <div className={className} onClick={onButtonClick}>
+      <View shrink={false} className={className} onClick={onButtonClick}>
         <i className={iconClassName} />
-      </div>
+      </View>
     );
   }
 
   templateClearButton({ onInputClear, iconClearClassName }) {
     return (
-      <div className='clear-button' onClick={onInputClear}>
+      <View shrink={false} className='clear-button' onClick={onInputClear}>
         <i className={iconClearClassName} />
-      </div>
+      </View>
     );
   }
 
@@ -81,10 +82,10 @@ export default class Input extends React.Component {
     return (
       <div className={className}>
         <input {...inputProps} />
-        <div className='button-wrapper'>
-          {inputButtonProps && this.templateInputButton(inputButtonProps)}
+        <View className='button-wrapper' vAlignContent='center'>
           {clearButtonProps && this.templateClearButton(clearButtonProps)}
-        </div>
+          {inputButtonProps && this.templateInputButton(inputButtonProps)}
+        </View>
       </div>
     );
   }

--- a/src/Picker.js
+++ b/src/Picker.js
@@ -2,6 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import t from 'tcomb';
 import { props } from 'tcomb-react';
+import View from 'react-flexview';
 import { pure, skinnable } from './utils';
 import { MomentDate, Value, Mode } from './utils/model';
 
@@ -52,9 +53,13 @@ export default class Picker extends React.Component {
 
   template({ className, onClick, value }) {
     return (
-      <div {...{ className, onClick }}>
+      <View
+        {...{ className, onClick }}
+        hAlignContent='center' vAlignContent='center'
+        basis='100%' shrink height='100%'
+      >
         <span>{value}</span>
-      </div>
+      </View>
     );
   }
 }

--- a/src/PickerTop.js
+++ b/src/PickerTop.js
@@ -2,6 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import t from 'tcomb';
 import { props } from 'tcomb-react';
+import View from 'react-flexview';
 import { pure, skinnable } from './utils';
 
 @pure
@@ -17,26 +18,32 @@ import { pure, skinnable } from './utils';
 export default class PickerTop extends React.Component {
   template({ value, fixed, previousDate, nextDate, handleClick, weekDays }) {
     return (
-      <div className='react-datepicker-top'>
-        <div className='display'>
-          <div className='react-datepicker-button button-left'
+      <View column className='react-datepicker-top'>
+        <View shrink={false} className='display'>
+          <View
+            className='react-datepicker-button button-left'
             onClick={previousDate}
+            vAlignContent='center' shrink={false}
           >
             &lt;
-          </div>
-          <div className={cx('react-datepicker-button button-label', { fixed })}
+          </View>
+          <View
+            className={cx('react-datepicker-button button-label', { fixed })}
             onClick={handleClick}
+            hAlignContent='center' vAlignContent='center' grow
           >
             <strong>{value}</strong>
-          </div>
-          <div className='react-datepicker-button button-right'
+          </View>
+          <View
+            className='react-datepicker-button button-right'
             onClick={nextDate}
+            vAlignContent='center' shrink={false}
           >
             &gt;
-          </div>
-        </div>
+          </View>
+        </View>
         {weekDays}
-      </div>
+      </View>
     );
   }
 }

--- a/src/Row.js
+++ b/src/Row.js
@@ -2,6 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import t from 'tcomb';
 import { props } from 'tcomb-react';
+import View from 'react-flexview';
 import { pure, skinnable } from './utils';
 import { Mode } from './utils/model';
 
@@ -22,9 +23,9 @@ export default class Row extends React.Component {
 
   template({ className, pickers }) {
     return (
-      <div className={className}>
+      <View className={className} width='100%' basis='100%' shrink>
         {pickers}
-      </div>
+      </View>
     );
   }
 

--- a/src/daypicker/DayPicker.js
+++ b/src/daypicker/DayPicker.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import t from 'tcomb';
 import { props } from 'tcomb-react';
+import View from 'react-flexview';
 import { pure, skinnable } from '../utils';
 import { Value, Mode, MomentDate } from '../utils/model';
 import DayPickerTop from './DayPickerTop';
@@ -43,10 +44,10 @@ export default class DayPicker extends React.Component {
 
   template({ dayPickerTopProps, dayPickerBodyProps }) {
     return (
-      <div className='react-datepicker-container day'>
+      <View column className='react-datepicker-container day'>
         <DayPickerTop {...dayPickerTopProps} />
         <DayPickerBody {...dayPickerBodyProps} />
-      </div>
+      </View>
     );
   }
 }

--- a/src/daypicker/DayPickerBody.js
+++ b/src/daypicker/DayPickerBody.js
@@ -2,6 +2,7 @@ import React from 'react';
 import range from 'lodash/range';
 import t from 'tcomb';
 import { props } from 'tcomb-react';
+import View from 'react-flexview';
 import { pure, skinnable } from '../utils';
 import { Value, Mode, MomentDate } from '../utils/model';
 import InvalidDate from '../InvalidDate';
@@ -64,9 +65,9 @@ export default class DayPickerBody extends React.Component {
     );
 
     return (
-      <div className='react-datepicker-body'>
+      <View column className='react-datepicker-body'>
         {rows}
-      </div>
+      </View>
     );
   }
 }

--- a/src/daypicker/DayPickerTop.js
+++ b/src/daypicker/DayPickerTop.js
@@ -2,6 +2,7 @@ import React from 'react';
 import capitalize from 'lodash/capitalize';
 import t from 'tcomb';
 import { props } from 'tcomb-react';
+import View from 'react-flexview';
 import { pure, skinnable } from '../utils';
 import { MomentDate, Mode } from '../utils/model';
 import { getWeekdaysMin } from '../utils/DateUtils.js';
@@ -41,9 +42,17 @@ export default class DayPickerTop extends React.Component {
   }
 
   templateWeekDays = ({ weekDays }) => (
-    <div className='week-days'>
-      {weekDays.map((dayMin, i) => <div className='week-day' key={i}>{dayMin}</div>)}
-    </div>
+    <View className='week-days' shrink={false}>
+      {weekDays.map((dayMin, i) => (
+        <View
+          className='week-day' basis='100%' shrink
+          hAlignContent='center' vAlignContent='center'
+          key={i}
+        >
+          {dayMin}
+        </View>
+      ))}
+    </View>
   )
 
   template({ weekDays, ...locales }) {

--- a/src/style.scss
+++ b/src/style.scss
@@ -55,6 +55,7 @@ $input-clear-button-color-hover: $vermillion !default;
 
 $input-opacity-disabled: .6 !default;
 
+$picker-width: 250px !default;
 $picker-border: $coolGrey !default;
 $picker-box-shadow: 2px 2px 2px $coolGrey !default;
 $picker-border-radius: 5px !default;
@@ -196,7 +197,7 @@ $picker-disabled-background: white !default;
   .react-datepicker-container {
     border: 1px solid $picker-border;
     border-radius: ($picker-border-radius + 1);
-    width: 250px;
+    width: $picker-width;
   }
 
   .react-datepicker-top {

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,3 +1,5 @@
+@import '~react-flexview/lib/flexView.css';
+
 $gradientGrey: linear-gradient(#FAFAFA, #E0E0E0);
 $gradientMediumGrey: linear-gradient(#FAFAFA, #A7ABAB);
 $alabaster: #F3F3F3;
@@ -149,39 +151,26 @@ $picker-disabled-background: white !default;
     right: 0;
     top: 0;
     height: 100%;
-    display: -webkit-flex;
-    display: flex;
-    -webkit-align-items: center;
-    align-items: center;
-  }
 
-  .input-button {
-    margin: 0;
-    height: 100%;
-    width: 50px;
-    display: flex;
-    display: -webkit-flex;
-    align-items: center;
-    -webkit-align-items: center;
-    justify-content: center;
-    -webkit-justify-content: center;
-    background: $input-button-background;
-    font-size: input-button-icon-size;
-    border-radius: 0 $input-border-radius $input-border-radius 0;
-    cursor: pointer;
-  }
+    .input-button {
+      margin: 0 10px;
+      background: $input-button-background;
+      font-size: $input-button-icon-size;
+      border-radius: 0 $input-border-radius $input-border-radius 0;
+      cursor: pointer;
 
-  .input-button:hover {
-    background: $input-button-background-hover;
-  }
+      &:hover {
+        background: $input-button-background-hover;
+      }
+    }
 
-  .clear-button {
-    margin-right: 10px;
-    cursor: pointer;
-    font-size: $input-clear-button-icon-size;
-    color: $input-clear-button-color;
-    &:hover {
-      color: $input-clear-button-color-hover;
+    .clear-button {
+      cursor: pointer;
+      font-size: $input-clear-button-icon-size;
+      color: $input-clear-button-color;
+      &:hover {
+        color: $input-clear-button-color-hover;
+      }
     }
   }
 }
@@ -219,43 +208,27 @@ $picker-disabled-background: white !default;
 
     .week-days {
       height: 35px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
 
       .week-day {
-        flex: 1 1 auto;
         cursor: default;
       }
     }
 
     .display {
       height: 35px;
-      display: flex;
 
       .react-datepicker-button {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        flex: 1 0 auto;
         text-decoration: none;
         padding: 4px;
         text-align: center;
         &.button-left {
+          padding: 4px 16px;
           border-top-left-radius: $picker-border-radius;
         }
         &.button-right {
+          padding: 4px 16px;
           border-top-right-radius: $picker-border-radius;
         }
-      }
-      .react-datepicker-button.button-left .slow {
-        margin-left: 10px;
-      }
-      .react-datepicker-button.button-right .fast{
-        margin-left: 10px;
-      }
-      .react-datepicker-button.button-label {
-        width: 120px;
       }
       .react-datepicker-button.button-label.fixed:hover {
         background: transparent;
@@ -268,7 +241,6 @@ $picker-disabled-background: white !default;
   }
 
   .react-datepicker-row {
-    display: flex;
     margin-top: 0px;
     width: 100%;
     &:not(:last-child) {
@@ -289,25 +261,21 @@ $picker-disabled-background: white !default;
     background: $picker-background;
     cursor: pointer;
     text-decoration: none;
-    flex: 1 1 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
     &:not(:last-child) {
       border-right: 1px solid $picker-border;
     }
   }
 
   .react-datepicker-picker.day {
-    height: 35px;
+    min-height: 30px;
   }
 
   .react-datepicker-picker.month {
-    height: 62px;
+    min-height: 65px;
   }
 
   .react-datepicker-picker.year {
-    height: 62px;
+    min-height: 65px;
   }
 
   .react-datepicker-picker:hover {
@@ -341,7 +309,6 @@ $picker-disabled-background: white !default;
     }
   }
   .react-datepicker-button {
-    display: block;
     text-align: center;
     cursor: pointer;
     text-decoration: none;

--- a/src/yearpicker/YearPicker.js
+++ b/src/yearpicker/YearPicker.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import t from 'tcomb';
 import { props } from 'tcomb-react';
+import View from 'react-flexview';
 import { pure, skinnable } from '../utils';
 import { MomentDate, Value, Mode } from '../utils/model';
 import YearPickerTop from './YearPickerTop';
@@ -52,10 +53,10 @@ export default class YearPicker extends React.Component {
 
   template({ yearPickerTopProps, yearPickerBodyProps }) {
     return (
-      <div className='react-datepicker-container year'>
+      <View column className='react-datepicker-container year'>
         <YearPickerTop {...yearPickerTopProps} />
         <YearPickerBody {...yearPickerBodyProps} />
-      </div>
+      </View>
     );
   }
 }


### PR DESCRIPTION
Issue #68

## Test Plan

### tests performed
layout looks fine in every state:

![image](https://cloud.githubusercontent.com/assets/4029499/17563897/c505623c-5f31-11e6-9b76-83e44fd301f2.png)

![image](https://cloud.githubusercontent.com/assets/4029499/17563901/ca15b84e-5f31-11e6-808e-6bc0beb9f55b.png)

![image](https://cloud.githubusercontent.com/assets/4029499/17563915/cf527b9e-5f31-11e6-84ac-331190c2fb46.png)

![image](https://cloud.githubusercontent.com/assets/4029499/17563926/de477762-5f31-11e6-8913-591c02e49454.png)

is flexible (modified width variable to 400px):
![image](https://cloud.githubusercontent.com/assets/4029499/17564088/8bdad252-5f32-11e6-8e9f-6ad10233254e.png)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
