### PR TITLE
#114: DatePickerInput is ignoring locale when initialized (closes #114)

### DIFF
--- a/src/DatePickerInput.js
+++ b/src/DatePickerInput.js
@@ -101,6 +101,9 @@ export default class DatePickerInput extends React.Component {
 
   constructor(props) {
     super(props);
+    if (props.locale) {
+      moment.locale(props.locale);
+    }
     const _date = this.getValueLink().value || props.defaultValue;
     const date = typeof _date === 'string' ? this.parsePropDateString(_date) : moment(_date);
     this.state = {


### PR DESCRIPTION
Closes #114

## Test Plan

### tests performed
- edit `example.js` as following:
  - remove  the `moment/locale/fr.js` 
  - remove `displayFormat` prop from `DatePickerInput`
  - pass a `value={new Date()} to the `DatePickerInput`

Date at first render is displayed as `24.04.2017`

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
