### PR TITLE
Changed parameter of onChange to Date (closes #129)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,13 +13,13 @@ export type Value = string | Date | moment.Moment  ; // | MomentDate
 
 export type ValueLink = {
   value? : Value,
-  requestChange(e: React.SyntheticEvent<KeyboardEvent | MouseEvent>): void
+  requestChange(e: Date): void
 }
 
 export interface DatePickerInputProps {
   value?: Value,
   valueLink?: ValueLink,
-  onChange?(e: React.SyntheticEvent<KeyboardEvent | MouseEvent>): void,
+  onChange?(e: Date): void,
   onShow?: () => void,
   onHide?: () => void,
   onClear?: () => void,

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,7 +50,7 @@ export interface DatePickerInputProps {
 export class DatePickerInput extends React.Component<DatePickerInputProps, void> {}
 
 export interface DatePickerProps {
-  onChange?: (e: React.SyntheticEvent<KeyboardEvent | MouseEvent>) => void,
+  onChange?: (e: Date) => void,
   value?: Value,
   valueLink?: ValueLink,
   defaultValue?: Value,


### PR DESCRIPTION
`onChange={(e) => console.log(e)}` gave me a Date, not an Event Object so I wasn't able to get the new date in my onChange method. This seemed to fix my problem when using this datepicker with Typescript.