### PR TITLE
Used exported ReactChildren type from tcomb-react instead of t.ReactChildren reference

### DIFF
--- a/src/PickerTop.js
+++ b/src/PickerTop.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
 import t from 'tcomb';
-import { props } from 'tcomb-react';
+import { props, ReactChildren } from 'tcomb-react';
 import View from 'react-flexview';
 import { pure, skinnable } from './utils';
 
@@ -13,7 +13,7 @@ import { pure, skinnable } from './utils';
   nextDate: t.maybe(t.Function),
   previousDate: t.maybe(t.Function),
   value: t.union([t.String, t.Number]),
-  weekDays: t.maybe(t.ReactChildren),
+  weekDays: t.maybe(ReactChildren),
   prevIconClassName: t.String,
   nextIconClassName: t.String
 })

--- a/src/Row.js
+++ b/src/Row.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
 import t from 'tcomb';
-import { props } from 'tcomb-react';
+import { props, ReactChildren } from 'tcomb-react';
 import View from 'react-flexview';
 import { pure, skinnable } from './utils';
 import { Mode } from './utils/model';
@@ -9,7 +9,7 @@ import { Mode } from './utils/model';
 @pure
 @skinnable()
 @props({
-  pickers: t.list(t.ReactChildren),
+  pickers: t.list(ReactChildren),
   mode: Mode
 })
 export default class Row extends React.Component {


### PR DESCRIPTION
I removed the usage of `t.ReactChildren` cause is going to be [deprecated ](https://github.com/gcanti/tcomb-react/releases/tag/v0.9.2) soon and cause it collides when the project has multiple version of `tcomb`.

