### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ export interface DatePickerInputProps {
   style?: object // used to omit from inputProps
 }
 
-export class DatePickerInput extends React.Component<DatePickerInputProps, void> {}
+export class DatePickerInput extends React.Component<DatePickerInputProps, {}> {}
 
 export interface DatePickerProps {
   onChange?: (e: Date) => void,


### PR DESCRIPTION
Closes #136 

Latest version of react + typescript started to complain when void is used as type parameter.  I changed it to an empty object and everything is ok again. :)