### PR TITLE
Replacing the datePickerInput string ref by a node ref

### DIFF
--- a/src/DatePickerInput.js
+++ b/src/DatePickerInput.js
@@ -101,6 +101,8 @@ export default class DatePickerInput extends React.Component {
     style: {}
   }
 
+  textInputRef = null;
+
   constructor(props) {
     super(props);
     if (props.locale) {
@@ -141,7 +143,7 @@ export default class DatePickerInput extends React.Component {
   }
 
   getDatePickerInput = () => {
-    return ReactDOM.findDOMNode(this.refs.datePickerInput);
+    return ReactDOM.findDOMNode(this.textInputRef);
   }
 
   isEventInsideDatePickerInput = (el) => {
@@ -287,7 +289,7 @@ export default class DatePickerInput extends React.Component {
 
   template({ className, style, inputProps, datePickerProps }) {
     return (
-      <div {...{ style, className }} ref='datePickerInput'>
+      <div {...{ style, className }} ref={input => { this.textInputRef = input; }}>
         <Input {...inputProps} />
         {datePickerProps && <DatePicker {...datePickerProps} />}
       </div>

--- a/src/DatePickerInput.js
+++ b/src/DatePickerInput.js
@@ -101,7 +101,7 @@ export default class DatePickerInput extends React.Component {
     style: {}
   }
 
-  textInputRef = null;
+  datePickerInputRef = null;
 
   constructor(props) {
     super(props);
@@ -143,7 +143,7 @@ export default class DatePickerInput extends React.Component {
   }
 
   getDatePickerInput = () => {
-    return ReactDOM.findDOMNode(this.textInputRef);
+    return ReactDOM.findDOMNode(this.datePickerInputRef);
   }
 
   isEventInsideDatePickerInput = (el) => {
@@ -289,7 +289,7 @@ export default class DatePickerInput extends React.Component {
 
   template({ className, style, inputProps, datePickerProps }) {
     return (
-      <div {...{ style, className }} ref={input => { this.textInputRef = input; }}>
+      <div {...{ style, className }} ref={input => { this.datePickerInputRef = input; }}>
         <Input {...inputProps} />
         {datePickerProps && <DatePicker {...datePickerProps} />}
       </div>


### PR DESCRIPTION
I came across an issue with your library when the library is built as part of a bundle, which is itself used by the consuming app.

(So rc-datepicker is built as part of a component library, which is bundled, and consumed by an app).

In that scenario, React complains about the `datePickerInput` string ref, and throws an exception, and since string ref are deprecated anyway (https://stackoverflow.com/questions/37468913/why-ref-string-is-legacy).
