### PR TITLE
Change @types/react version to be more flexible

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-dom": "^0.14 || ^15.0 || ^16.0"
   },
   "dependencies": {
-    "@types/react": "^15.0.23",
+    "@types/react": "^0.14 || ^15.0 || ^16.0",
     "classnames": "^2.2.5",
     "lodash": "^4.13.1",
     "moment": "^2.13.0",


### PR DESCRIPTION
I came across an issue with your library when the library is built as part of a application written with TypeScript .

There are problems with typings mismatch.  Let package-manager decide which version is the best. 
It should be also moved into the `devDependencies` but it's just my opinion.