### PR TITLE
Added support for multiple date formats

### DIFF
--- a/examples/examples.js
+++ b/examples/examples.js
@@ -38,6 +38,7 @@ class Example extends React.Component {
           <div className='ui input'>
             <DatePickerInput
               disabled={this.state.disabled}
+              format={['YYYYMMDD', 'YYYY-MM-DD', 'YYMMDD', 'YY-MM-DD']}
               displayFormat='DD/MM/YYYY'
               returnFormat='YYYY-MM-DD'
               className='my-react-component'

--- a/src/DatePickerInput.js
+++ b/src/DatePickerInput.js
@@ -33,7 +33,7 @@ export const Props = {
   fixedMode: t.maybe(t.Boolean),
   displayFormat: t.maybe(t.String),
   returnFormat: t.maybe(t.String),
-  format: t.maybe(t.String),
+  format: t.maybe(t.Array),
   validationFormat: t.maybe(t.String),
   showOnInputClick: t.maybe(t.Boolean),
   closeOnClickOutside: t.maybe(t.Boolean),

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -40,11 +40,12 @@ export default function format(Component) {
   };
 
   Component.prototype.parseInputDateString = function(dateString, props) {
-    const format = this.getDisplayFormat(props);
-    if (!format) {
+    const { format } = (props || this.props);
+    const parseFormat = format ? format : this.getDisplayFormat(props);
+    if (!parseFormat) {
       return moment(dateString);
     } else {
-      return moment(dateString, format, true);
+      return moment(dateString, parseFormat, true);
     }
   };
 


### PR DESCRIPTION
Added support for multiple input date format. Component prop 'format' takes an array of moment date formats like this: 
format={['YYYYMMDD', 'YYYY-MM-DD', 'YYMMDD', 'YY-MM-DD']}
This allows you to type date in multiple formats and get the result back in specified format.

Tested locally and it is working fine.

I think this is one of the best react datepicker available, good styling and nice features. With this feature it meets all my needs. 