### PR TITLE
Fix #169 : Add event as 3rd parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,14 +16,18 @@ export type ValueLink = {
   requestChange(e: Date): void
 }
 
+export type DateOnChangeHandlerWithEvent = {
+  // Event will not emit if it's selected from DatePicker (not typed)
+  (jsDate: Date, dateString: string, event?: React.ChangeEvent<HTMLInputElement>): void;
+}
+
 export type DateOnChangeHandler = {
   (jsDate: Date, dateString: string): void;
 }
-
 export interface DatePickerInputProps {
   value?: Value,
   valueLink?: ValueLink,
-  onChange?: DateOnChangeHandler,
+  onChange?: DateOnChangeHandlerWithEvent,
   onShow?: () => void,
   onHide?: () => void,
   onClear?: () => void,

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.5.3",
     "node-libs-browser": "^1.0.0",
-    "node-sass": "^3.7.0",
+    "node-sass": "^4.13.0",
     "react": "^0.14",
     "react-addons-test-utils": "^0.14.8",
     "react-dom": "^0.14",

--- a/src/DatePickerInput.js
+++ b/src/DatePickerInput.js
@@ -216,7 +216,10 @@ export default class DatePickerInput extends React.Component {
     }
   }
 
-  onChangeInput = ({ target: { value: dateString } }) => {
+  onChangeInput = (event) => {
+    const { target: { value: dateString } } = event;
+    event.persist();
+
     if (dateString || this.state.date) {
       const parsedDate = this.parseInputDateString(dateString);
       const date = parsedDate.isValid() ? parsedDate : this.state.date;
@@ -228,7 +231,7 @@ export default class DatePickerInput extends React.Component {
         dateString,
         date,
         hasValue: parsedDate.isValid()
-      }, () => this.getValueLink().requestChange(jsDate, returnedDateString));
+      }, () => this.getValueLink().requestChange(jsDate, returnedDateString, event));
     } else if (!dateString) {
       this.setState({ dateString });
     }


### PR DESCRIPTION
We couldn't get the input value from the onChange, so I pass event to the handler, which I think it should be passed as 1st parameter, to align with the default behaviour of native onChange handler. 

For the time being, to avoid breaking changes, I place it as the 3rd parameter.

Feel free to make changes.