### PR TITLE
Fix #172 onChange is not triggered when empty

### DIFF
--- a/src/DatePickerInput.js
+++ b/src/DatePickerInput.js
@@ -217,21 +217,17 @@ export default class DatePickerInput extends React.Component {
   }
 
   onChangeInput = ({ target: { value: dateString } }) => {
-    if (dateString || this.state.date) {
-      const parsedDate = this.parseInputDateString(dateString);
-      const date = parsedDate.isValid() ? parsedDate : this.state.date;
+    const parsedDate = this.parseInputDateString(dateString);
+    const date = parsedDate.isValid() ? parsedDate : this.state.date;
 
-      const jsDate = parsedDate.isValid() ? parsedDate.toDate() : INVALID;
-      const returnedDateString = jsDate ? this.formatReturnedDate(parsedDate) : INVALID;
+    const jsDate = parsedDate.isValid() ? parsedDate.toDate() : INVALID;
+    const returnedDateString = jsDate ? this.formatReturnedDate(parsedDate) : INVALID;
 
-      this.setState({
-        dateString,
-        date,
-        hasValue: parsedDate.isValid()
-      }, () => this.getValueLink().requestChange(jsDate, returnedDateString));
-    } else if (!dateString) {
-      this.setState({ dateString });
-    }
+    this.setState({
+      dateString,
+      date,
+      hasValue: parsedDate.isValid()
+    }, () => this.getValueLink().requestChange(jsDate, returnedDateString));
   }
 
   getLocals(props) {


### PR DESCRIPTION
Previous was checking whether `dateString` is existed, I don't understand why, and it's causing the bug so I removed it.